### PR TITLE
Enable using synapseClient and rGithubClient

### DIFF
--- a/mPower-summaries.R
+++ b/mPower-summaries.R
@@ -7,11 +7,11 @@ if(!require(synapseClient)){
   require(synapseClient)
 }
 
-if(!require(synapseClient)){
+if(!require(rGithubClient)){
   ## The packages rGithubClient is not on CRAN. Get it from using the useful devtools.
   install.packages("devtools")
   devtools::install_github("brian-bot/rGithubClient")
-  require(synapseClient)
+  require(rGithubClient)
 }
 
 require(ggplot2)

--- a/mPower-summaries.R
+++ b/mPower-summaries.R
@@ -1,3 +1,10 @@
+## The packages synapseClient and rGithubClient are not in standard CRAN,
+## so get them from synapse and github.
+source("http://depot.sagebase.org/CRAN.R")
+pkgInstall("synapseClient")
+install.packages("devtools")
+devtools::install_github("brian-bot/rGithubClient")
+
 require(synapseClient)
 require(rGithubClient)
 require(ggplot2)

--- a/mPower-summaries.R
+++ b/mPower-summaries.R
@@ -1,13 +1,21 @@
 ## The packages synapseClient and rGithubClient are not in standard CRAN,
 ## so get them from synapse and github.
-source("http://depot.sagebase.org/CRAN.R")
-pkgInstall("synapseClient")
-install.packages("devtools")
-devtools::install_github("brian-bot/rGithubClient")
+if(!require(synapseClient)){
+  ## The packages synapseClient is not on CRAN. Get it from sagebase.
+  source("http://depot.sagebase.org/CRAN.R")
+  pkgInstall("synapseClient")
+  require(synapseClient)
+}
 
-require(synapseClient)
-require(rGithubClient)
+if(!require(synapseClient)){
+  ## The packages rGithubClient is not on CRAN. Get it from using the useful devtools.
+  install.packages("devtools")
+  devtools::install_github("brian-bot/rGithubClient")
+  require(synapseClient)
+}
+
 require(ggplot2)
+## The following will prompt for a username and password.
 synapseLogin()
 
 firstDate <- as.Date("2015-03-09")


### PR DESCRIPTION
2 packages are not in CRAN, so enable retrieving them from non-standard locations.  
I have made a change to mPower-Summaries.R to enable new users to obtain the packages in these files.  This appears to be necessary, though there may be a cleaner way to do it.  

